### PR TITLE
chore: rebase project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,9 @@
 name: Build & Release hezhijie0327/GFWList2PAC
 
 on:
-    push:
-        branches: [main]
-    schedule:
-        - cron: "0 0 * * *"
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
     build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-# Current Version: 1.0.4
-
 name: Build & Release hezhijie0327/GFWList2PAC
 
 on:
@@ -16,7 +14,7 @@ jobs:
               uses: actions/checkout@v4
             - name: Step 2 - Build GFWList2PAC
               run: |
-                  curl -s "https://raw.githubusercontent.com/hezhijie0327/GFWList2PAC/source/release.sh" | sudo bash
+                  bash release.sh
             - name: Step 3 - Release GFWList2PAC
               run: |
                   curl -s "https://raw.githubusercontent.com/hezhijie0327/Toolkit/main/Git.sh" > "/tmp/Git.sh"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,207 @@
+Copyright 2026 Zhijie He
+
+Licensed under the Apache License, Version 2.0 with Commons Clause v1.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+    https://commonsclause.com/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+===========================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+===========================================================================
+
+Commons Clause License Condition v1.0
+
+The Software is provided to you by the Licensor under the Apache License, as defined above, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you, the right to Sell the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software. Any license notice or attribution required by the License must also include this Commons Clause License Condition notice.
+
+Software: GFWList2PAC
+License: Apache 2.0 with Commons Clause v1.0
+Licensor: Zhijie He

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+## How to get and use?
+# git clone "https://github.com/hezhijie0327/GFWList2PAC.git" && bash ./GFWList2PAC/release.sh
+
+## Function
+# Get Data
+function GetData() {
+    cnacc_domain=(
+        "https://raw.githubusercontent.com/hezhijie0327/GFWList2AGH/main/gfwlist2domain/whitelist_full.txt"
+    )
+    gfwlist_domain=(
+        "https://raw.githubusercontent.com/hezhijie0327/GFWList2AGH/main/gfwlist2domain/blacklist_full.txt"
+    )
+    rm -rf ./gfwlist2pac_* ./Temp && mkdir ./Temp && cd ./Temp
+    for cnacc_domain_task in "${!cnacc_domain[@]}"; do
+        curl -s --connect-timeout 15 "${cnacc_domain[$cnacc_domain_task]}" >> ./cnacc_domain.tmp
+    done
+    for gfwlist_domain_task in "${!gfwlist_domain[@]}"; do
+        curl -s --connect-timeout 15 "${gfwlist_domain[$gfwlist_domain_task]}" >> ./gfwlist_domain.tmp
+    done
+}
+# Analyse Data
+function AnalyseData() {
+    cnacc_data=($(cat ./cnacc_domain.tmp | awk "{ print $2 }"))
+    gfwlist_data=($(cat ./gfwlist_domain.tmp | awk "{ print $2 }"))
+}
+# Generate Header Information
+function GenerateHeaderInformation() {
+    gfwlist2pac_checksum=$(date "+%s" | base64)
+    gfwlist2pac_expires="3 hours (update frequency)"
+    gfwlist2pac_homepage="https://github.com/hezhijie0327/GFWList2PAC"
+    gfwlist2pac_timeupdated=$(date -d @$(echo "${gfwlist2pac_checksum}" | base64 -d) "+%Y-%m-%dT%H:%M:%S%:z")
+    gfwlist2pac_title=$(if [ "${cnacc_gfwlist}" == "cnacc" ]; then echo "Zhijie's CNACCList"; elif [ "${cnacc_gfwlist}" == "gfwlist" ]; then echo "Zhijie's GFWList"; else exit 1; fi)
+    gfwlist2pac_version=$(curl -s --connect-timeout 15 "https://raw.githubusercontent.com/hezhijie0327/GFWList2PAC/source/release.sh" | grep "Current\ Version" | sed "s/\#\ Current\ Version\:\ //g")-$(date -d @$(echo "${gfwlist2pac_checksum}" | base64 -d) "+%Y%m%d")-$((10#$(date -d @$(echo "${gfwlist2pac_checksum}" | base64 -d) "+%H") / 3))
+    function gfwlist2pac_autoproxy() {
+        echo "[AutoProxy 0.2.9]" > ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.txt
+        echo "! Checksum: ${gfwlist2pac_checksum}" >> ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.txt
+        echo "! Title: ${gfwlist2pac_title} for Auto Proxy" >> ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.txt
+        echo "! Version: ${gfwlist2pac_version}" >> ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.txt
+        echo "! TimeUpdated: ${gfwlist2pac_timeupdated}" >> ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.txt
+        echo "! Expires: ${gfwlist2pac_expires}" >> ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.txt
+        echo "! Homepage: ${gfwlist2pac_homepage}" >> ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.txt
+    }
+    function gfwlist2pac_clash() {
+        echo "payload:" > ../gfwlist2pac_${cnacc_gfwlist}_clash.yaml
+        echo "# Checksum: ${gfwlist2pac_checksum}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash.yaml
+        echo "# Title: ${gfwlist2pac_title} for Clash" >> ../gfwlist2pac_${cnacc_gfwlist}_clash.yaml
+        echo "# Version: ${gfwlist2pac_version}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash.yaml
+        echo "# TimeUpdated: ${gfwlist2pac_timeupdated}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash.yaml
+        echo "# Expires: ${gfwlist2pac_expires}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash.yaml
+        echo "# Homepage: ${gfwlist2pac_homepage}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash.yaml
+    }
+    function gfwlist2pac_clash_premium() {
+        echo "payload:" > ../gfwlist2pac_${cnacc_gfwlist}_clash_premium.yaml
+        echo "# Checksum: ${gfwlist2pac_checksum}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash_premium.yaml
+        echo "# Title: ${gfwlist2pac_title} for Clash Premium" >> ../gfwlist2pac_${cnacc_gfwlist}_clash_premium.yaml
+        echo "# Version: ${gfwlist2pac_version}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash_premium.yaml
+        echo "# TimeUpdated: ${gfwlist2pac_timeupdated}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash_premium.yaml
+        echo "# Expires: ${gfwlist2pac_expires}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash_premium.yaml
+        echo "# Homepage: ${gfwlist2pac_homepage}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash_premium.yaml
+    }
+    function gfwlist2pac_shadowrocket() {
+        echo "# Checksum: ${gfwlist2pac_checksum}" > ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "# Title: ${gfwlist2pac_title} for Shadowrocket" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "# Version: ${gfwlist2pac_version}" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "# TimeUpdated: ${gfwlist2pac_timeupdated}" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "# Expires: ${gfwlist2pac_expires}" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "# Homepage: ${gfwlist2pac_homepage}" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "[General]" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "bypass-system = true" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "bypass-tun = 10.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.0.0.0/24, 192.0.2.0/24, 192.88.99.0/24, 192.168.0.0/16, 198.18.0.0/15, 198.51.100.0/24, 203.0.113.0/24, 224.0.0.0/4, 240.0.0.0/4, 255.255.255.255/32" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "dns-server = https://dns.alidns.com/dns-query, https://doh.pub/dns-query" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "ipv6 = true" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "skip-proxy = 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, localhost, *.local" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "[Rule]" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+    }
+    function gfwlist2pac_surge() {
+        echo "# Checksum: ${gfwlist2pac_checksum}" > ../gfwlist2pac_${cnacc_gfwlist}_surge.yaml
+        echo "# Title: ${gfwlist2pac_title} for Surge" >> ../gfwlist2pac_${cnacc_gfwlist}_surge.yaml
+        echo "# Version: ${gfwlist2pac_version}" >> ../gfwlist2pac_${cnacc_gfwlist}_surge.yaml
+        echo "# TimeUpdated: ${gfwlist2pac_timeupdated}" >> ../gfwlist2pac_${cnacc_gfwlist}_surge.yaml
+        echo "# Expires: ${gfwlist2pac_expires}" >> ../gfwlist2pac_${cnacc_gfwlist}_surge.yaml
+        echo "# Homepage: ${gfwlist2pac_homepage}" >> ../gfwlist2pac_${cnacc_gfwlist}_surge.yaml
+    }
+    function gfwlist2pac_quantumult() {
+        echo "# Checksum: ${gfwlist2pac_checksum}" > ../gfwlist2pac_${cnacc_gfwlist}_quantumult.yaml
+        echo "# Title: ${gfwlist2pac_title} for Quantumult" >> ../gfwlist2pac_${cnacc_gfwlist}_quantumult.yaml
+        echo "# Version: ${gfwlist2pac_version}" >> ../gfwlist2pac_${cnacc_gfwlist}_quantumult.yaml
+        echo "# TimeUpdated: ${gfwlist2pac_timeupdated}" >> ../gfwlist2pac_${cnacc_gfwlist}_quantumult.yaml
+        echo "# Expires: ${gfwlist2pac_expires}" >> ../gfwlist2pac_${cnacc_gfwlist}_quantumult.yaml
+        echo "# Homepage: ${gfwlist2pac_homepage}" >> ../gfwlist2pac_${cnacc_gfwlist}_quantumult.yaml
+    }
+    function gfwlist2pac_v2raya() {
+        echo "# Checksum: ${gfwlist2pac_checksum}" > ../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt
+        echo "# Title: ${gfwlist2pac_title} for v2rayA" >> ../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt
+        echo "# Version: ${gfwlist2pac_version}" >> ../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt
+        echo "# TimeUpdated: ${gfwlist2pac_timeupdated}" >> ../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt
+        echo "# Expires: ${gfwlist2pac_expires}" >> ../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt
+        echo "# Homepage: ${gfwlist2pac_homepage}" >> ../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt
+        echo -n "domain(" >> ../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt
+    }
+    function gfwlist2pac_v2rayn() {
+        echo "# Checksum: ${gfwlist2pac_checksum}" > ../gfwlist2pac_${cnacc_gfwlist}_v2rayn.txt
+        echo "# Title: ${gfwlist2pac_title} for v2rayN" >> ../gfwlist2pac_${cnacc_gfwlist}_v2rayn.txt
+        echo "# Version: ${gfwlist2pac_version}" >> ../gfwlist2pac_${cnacc_gfwlist}_v2rayn.txt
+        echo "# TimeUpdated: ${gfwlist2pac_timeupdated}" >> ../gfwlist2pac_${cnacc_gfwlist}_v2rayn.txt
+        echo "# Expires: ${gfwlist2pac_expires}" >> ../gfwlist2pac_${cnacc_gfwlist}_v2rayn.txt
+        echo "# Homepage: ${gfwlist2pac_homepage}" >> ../gfwlist2pac_${cnacc_gfwlist}_v2rayn.txt
+    }
+    gfwlist2pac_autoproxy
+    gfwlist2pac_clash
+    gfwlist2pac_clash_premium
+    gfwlist2pac_shadowrocket
+    gfwlist2pac_surge
+    gfwlist2pac_quantumult
+    gfwlist2pac_v2raya
+    gfwlist2pac_v2rayn
+}
+# Generate Footer Information
+function GenerateFooterInformation() {
+    function gfwlist2pac_shadowrocket() {
+        echo "FINAL,DIRECT" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+    }
+    function gfwlist2pac_v2raya() {
+        if [ "${cnacc_gfwlist}" == "cnacc" ]; then
+            echo -n ")->direct" >> ../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt
+        else
+            echo -n ")->proxy" >> ../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt
+        fi
+        sed -i 's/,)/)/g' "../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt"
+    }
+    gfwlist2pac_shadowrocket
+    gfwlist2pac_v2raya
+}
+# Encode Data
+function EncodeData() {
+    function gfwlist2pac_autoproxy() {
+        cat ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.txt | base64 > ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.base64
+        mv ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.base64 ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.txt
+    }
+    gfwlist2pac_autoproxy
+}
+# Output Data
+function OutputData() {
+    cnacc_gfwlist="cnacc" && GenerateHeaderInformation
+    for cnacc_data_task in "${!cnacc_data[@]}"; do
+        echo "@@||${cnacc_data[cnacc_data_task]}^" >> ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.txt
+        echo "  - DOMAIN-SUFFIX,${cnacc_data[cnacc_data_task]}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash.yaml
+        echo "  - '+.${cnacc_data[cnacc_data_task]}'" >> ../gfwlist2pac_${cnacc_gfwlist}_clash_premium.yaml
+        echo "DOMAIN-SUFFIX,${cnacc_data[cnacc_data_task]},DIRECT" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "DOMAIN-SUFFIX,${cnacc_data[cnacc_data_task]},DIRECT" >> ../gfwlist2pac_${cnacc_gfwlist}_surge.yaml
+        echo "DOMAIN-SUFFIX,${cnacc_data[cnacc_data_task]},DIRECT" >> ../gfwlist2pac_${cnacc_gfwlist}_quantumult.yaml
+        echo -n "domain:${cnacc_data[cnacc_data_task]}," >> ../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt
+        echo "domain:${cnacc_data[cnacc_data_task]}," >> ../gfwlist2pac_${cnacc_gfwlist}_v2rayn.txt
+    done
+    GenerateFooterInformation && EncodeData
+    cnacc_gfwlist="gfwlist" && GenerateHeaderInformation
+    for gfwlist_data_task in "${!gfwlist_data[@]}"; do
+        echo "||${gfwlist_data[gfwlist_data_task]}^" >> ../gfwlist2pac_${cnacc_gfwlist}_autoproxy.txt
+        echo "  - DOMAIN-SUFFIX,${gfwlist_data[gfwlist_data_task]}" >> ../gfwlist2pac_${cnacc_gfwlist}_clash.yaml
+        echo "  - '+.${gfwlist_data[gfwlist_data_task]}'" >> ../gfwlist2pac_${cnacc_gfwlist}_clash_premium.yaml
+        echo "DOMAIN-SUFFIX,${gfwlist_data[gfwlist_data_task]},PROXY" >> ../gfwlist2pac_${cnacc_gfwlist}_shadowrocket.conf
+        echo "DOMAIN-SUFFIX,${gfwlist_data[gfwlist_data_task]},PROXY" >> ../gfwlist2pac_${cnacc_gfwlist}_surge.yaml
+        echo "DOMAIN-SUFFIX,${gfwlist_data[gfwlist_data_task]},PROXY" >> ../gfwlist2pac_${cnacc_gfwlist}_quantumult.yaml
+        echo -n "domain:${gfwlist_data[gfwlist_data_task]}," >> ../gfwlist2pac_${cnacc_gfwlist}_v2raya.txt
+        echo "domain:${gfwlist_data[gfwlist_data_task]}," >> ../gfwlist2pac_${cnacc_gfwlist}_v2rayn.txt
+    done
+    GenerateFooterInformation && EncodeData
+    cd .. && rm -rf ./Temp
+    exit 0
+}
+## Process
+# Call GetData
+GetData
+# Call AnalyseData
+AnalyseData
+# Call OutputData
+OutputData


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

切换工作流程以使用本地的发布脚本并调整其触发方式，同时将发布脚本加入代码仓库。

增强功能：
- 添加自包含的 `release.sh` 脚本，用于从上游域名列表生成 GFWList2PAC 输出。

构建：
- 更新 GitHub Actions 工作流程，使其仅在定时或手动触发时运行，并调用本地发布脚本，而不是远程下载脚本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch the workflow to use a local release script and adjust its triggers while adding the release script to the repository.

Enhancements:
- Add a self-contained release.sh script to generate GFWList2PAC outputs from upstream domain lists.

Build:
- Update the GitHub Actions workflow to run only on schedule or manual dispatch and to invoke a local release script instead of downloading it remotely.

</details>